### PR TITLE
uwsgi compatibility

### DIFF
--- a/src/cgi.c
+++ b/src/cgi.c
@@ -599,9 +599,6 @@ int send_fcgi_request(t_session *session, int sock) {
 			return -1;
 		}
 
-		if (send_fcgi_buffer(&fcgi_buffer, NULL, 0) == -1) {
-			return -1;
-		}
 	} else if (session->uploaded_file != NULL) {
 		/* Send uploaded file to FastCGI program
 		 */
@@ -623,6 +620,12 @@ int send_fcgi_request(t_session *session, int sock) {
 		if (send_fcgi_buffer(&fcgi_buffer, NULL, 0) == -1) {
 			return -1;
 		}
+	}
+
+	/* Send zero-length STDIN record to indicate end of request
+	 */
+	if (send_fcgi_buffer(&fcgi_buffer, NULL, 0) == -1) {
+		return -1;
 	}
 
 	return 0;

--- a/src/cgi.c
+++ b/src/cgi.c
@@ -616,10 +616,6 @@ int send_fcgi_request(t_session *session, int sock) {
 		if (bytes_read == -1) {
 			return -1;
 		}
-
-		if (send_fcgi_buffer(&fcgi_buffer, NULL, 0) == -1) {
-			return -1;
-		}
 	}
 
 	/* Send zero-length STDIN record to indicate end of request

--- a/src/envir.c
+++ b/src/envir.c
@@ -245,10 +245,6 @@ void set_environment(t_session *session, t_fcgi_buffer *fcgi_buffer) {
 		add_to_environment(fcgi_buffer, "HTTP_GENERATED_ERROR", value);
 	}
 
-	if (session->cookie != NULL) {
-		add_to_environment(fcgi_buffer, "HTTP_COOKIE", session->cookie);
-	}
-
 	envir = session->host->envir_str;
 	while (envir != NULL) {
 		if (strncmp(envir->key, "CGIWRAP_", 8) != 0) {


### PR DESCRIPTION
**symptom:** on GET requests, uwsgi got stuck waiting for more data from hiawatha

**solution:** always send empty STDIN record to terminate request, regardles of request type (i.e. for GET as well as POST)

In the fastcgi SPEC (http://www.mit.edu/~yandros/doc/specs/fcgi-spec.html)  all the examples show empty FCGI_STDIN records being sent by the web server before the application starts responding with FCGI_STDOUT records.

The simplest such example from appendix B:

  A simple request with no data on stdin, and a successful response:

    {FCGI_BEGIN_REQUEST,   1, {FCGI_RESPONDER, 0}} 
    {FCGI_PARAMS,          1, "\013\002SERVER_PORT80\013\016SERVER_ADDR199.170.183.42 ... "}
    {FCGI_PARAMS,          1, ""} 
    {FCGI_STDIN,           1, ""}    <-------- this is what used to get skipped

        {FCGI_STDOUT,      1, "Content-type: text/html\r\n\r\n<html>\n<head> ... "}
        {FCGI_STDOUT,      1, ""} 
        {FCGI_END_REQUEST, 1, {0, FCGI_REQUEST_COMPLETE}}

Hiawatha used to only send a terminating empty FCGI_STDIN record if there were non-empty FCGI_STDIN records to send first, i.e. for a POST request rather than a GET.

The missing FCGI_STDIN on GET requests made uwsgi fastcgi implementation keep waiting for the request to end. Always sending an empty FCGI_STDIN tells uwsgi that the request is done so it can go ahead and process it. 
