### PR TITLE
Full REST api

### DIFF
--- a/src/envir.c
+++ b/src/envir.c
@@ -176,10 +176,8 @@ void set_environment(t_session *session, t_fcgi_buffer *fcgi_buffer) {
 		add_to_environment(fcgi_buffer, "QUERY_STRING", session->vars);
 	}
 
-	if (session->body != NULL) {
-		snprintf(len, 19, "%ld", session->content_length);
-		len[19] = '\0';
-		add_to_environment(fcgi_buffer, "CONTENT_LENGTH", len);
+	if (session->body != NULL || session->uploaded_file != NULL) {
+		http_header_to_environment(session, fcgi_buffer, "Content-Length:", "CONTENT_LENGTH");
 		http_header_to_environment(session, fcgi_buffer, "Content-Type:", "CONTENT_TYPE");
 	}
 

--- a/src/target.c
+++ b/src/target.c
@@ -1544,7 +1544,13 @@ int handle_delete_request(t_session *session) {
 			break;
 	}
 
-	/* Don't delete directories
+	/* If URI is mapped to CGI, destination is virtual not real file
+	 */
+	if (session->cgi_type != no_cgi) {
+		return execute_cgi(session);
+	}
+
+	/* If destination is not virtual, needs to be file not directory
 	 */
 	if (session->uri_is_dir) {
 		return 405;

--- a/src/target.c
+++ b/src/target.c
@@ -1348,6 +1348,14 @@ int handle_put_request(t_session *session) {
 			break;
 	}
 
+	/* If URI is mapped to CGI, destination is virtual not real file
+	 */
+	if (session->cgi_type != no_cgi) {
+		return execute_cgi(session);
+	}
+
+	/* If destination is not virtual, needs to be file not directory
+	 */
 	if (session->uri_is_dir) {
 		return 405;
 	}

--- a/src/workers.c
+++ b/src/workers.c
@@ -897,7 +897,7 @@ no_websocket:
 		}
 	}
 
-	if (((session->request_method != PUT) && (session->request_method != DELETE)) || session->host->webdav_app) {
+	if ((session->request_method != DELETE) || session->host->webdav_app) {
 		check_target_is_cgi(session);
 	}
 

--- a/src/workers.c
+++ b/src/workers.c
@@ -854,6 +854,8 @@ no_websocket:
 			}
 	}
 
+	check_target_is_cgi(session);
+
 	switch (is_directory(session->file_on_disk)) {
 		case error:
 			return 500;
@@ -875,7 +877,7 @@ no_websocket:
 			log_error(session, fb_filesystem);
 			return 403;
 		case not_found:
-			if (session->request_method == DELETE) {
+			if (session->request_method == DELETE && session->cgi_type == no_cgi) {
 				return 404;
 			}
 	}
@@ -895,10 +897,6 @@ no_websocket:
 		} else {
 			return 301;
 		}
-	}
-
-	if ((session->request_method != DELETE) || session->host->webdav_app) {
-		check_target_is_cgi(session);
 	}
 
 	/* Handle request based on request method


### PR DESCRIPTION
Allow PUT requests to be sent to fastcgi apps:

The http 1.1 standard does not address whether virtual directories served by a cgi program should be supported, but at least it doesn't seem to forbid it, only forbidding automatic redirection from one directory to another. Thus rewrite rules should be disabled for PUT, but sending the request to the client-specified path that happens to be a virtual directory served by an app and stored in a database (rather than a normal directory in a mounted filesystem) seems legitimate.

Allow DELETE requests to be sent to fastcgi apps:

Analogous reasoning -- many REST apps use delete requests to delete virtual resources.