### PR TITLE
logrotate syntax fix

### DIFF
--- a/extra/logrotate.in
+++ b/extra/logrotate.in
@@ -6,5 +6,7 @@
 	missingok
 	create 640 www-data www-data
 	sharedscripts
-	/usr/bin/killall -HUP hiawatha
+	postrotate
+		/usr/bin/killall -HUP hiawatha
+	endscript
 }


### PR DESCRIPTION
fixes this error:
```
/etc/cron.daily/logrotate:
error: hiawatha:9 unexpected log filename
error: found error in /var/log/hiawatha/access.log , skipping
```