### PR TITLE
sign .changes when building DEB

### DIFF
--- a/extra/make_debian_extra
+++ b/extra/make_debian_extra
@@ -52,10 +52,8 @@ mv hiawatha_${version}.dsc.asc hiawatha_${version}.dsc
 cd build_debian_package
 dpkg-genchanges > ../hiawatha_${version}.changes
 cd ..
-if [ -x /usr/bin/gpg ] && [ "`gpg -K | grep uid | grep 'Hugo Leisink' | wc -l`" = "1" ]; then
-	gpg --clearsign hiawatha_${version}.changes
-	mv hiawatha_${version}.changes.asc hiawatha_${version}.changes
-fi
+gpg --clearsign hiawatha_${version}.changes
+mv hiawatha_${version}.changes.asc hiawatha_${version}.changes
 
 # Done
 #


### PR DESCRIPTION
fixes this error:
```
$ gpg --verify hiawatha_10.5.changes 
gpg: no valid OpenPGP data found.
gpg: the signature could not be verified.
Please remember that the signature file (.sig or .asc)
should be the first file given on the command line.
```